### PR TITLE
Return promise to call 'then' on it

### DIFF
--- a/src/adapter/rest.js
+++ b/src/adapter/rest.js
@@ -76,7 +76,7 @@ export default Adapter.extend({
 		const urls = this.buildMultipleUrls(typeKey, ids);
 		const promises = urls.map((url) => this.ajax(url, 'GET'));
 
-		Promise.all(promises).then((payloads) => {
+		return Promise.all(promises).then((payloads) => {
 			const payload = this.mergePayloads(payloads);
 			return this.deserialize(payload, { requestType: 'findMany', recordType: typeKey, ids });
 		});


### PR DESCRIPTION
I was getting an error when fetching a bunch of objects that have GUIDs:

`TypeError: Cannot read property 'then' of undefined
    at _ember.default.Object.extend._findMany (ember-graph.js:6928)
    at _ember.default.Object.extend.find (ember-graph.js:6832)
    at relationship (ember-graph.js:3336)
    at null.<anonymous> (ember-graph.js:7411)
    at Descriptor.ComputedPropertyPrototype.get (ember.js:12639)
    at get (ember.js:17896)
    at __exports__.default.Mixin.create.unknownProperty (ember.js:29664)
    at get (ember.js:17907)
    at _getPath (ember.js:17982)
    at get (ember.js:17892)`

This fixes the error, cheers!