### PR TITLE
Gordonkristan patch 2

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,1 +1,0 @@
-ember-graph.com

--- a/tasks/setup_site_structure.js
+++ b/tasks/setup_site_structure.js
@@ -9,7 +9,6 @@ module.exports = function(grunt) {
 
 		execSync('cp -r site/fonts site_build/');
 		execSync('cp -r site/javascripts site_build/');
-		execSync('cp -r site/CNAME site_build/');
 		execSync('cp -r site/index.html site_build/');
 
 		execSync('mkdir -p site_build/stylesheets');


### PR DESCRIPTION
This will prevent Github pages from looking for the custom domain. Once the DNS caches clear the doc link should work fine (you can use a proxy in the meantime).